### PR TITLE
Set cross-origin-resource-policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ const app = buildOpenapiExpress({
     poweredBy: 'Pon.Bike',
     loggerOptions: {
         level: 'info'
-    }
+    },
+    origin = '*'
 })
 ```
 
@@ -109,6 +110,13 @@ It will set the the body parser limit, e.g. `app.use(bodyParser.json({ limit: '1
 The field `poweredBy` should be a string, but is optional.
 The default value is `Pon.Bike`.
 It will set a header `X-Powered-By`.
+
+### origin
+
+The field `origin` can be set for the CORS.
+The default value is `*`.
+It will also change the `cross-origin-resource-policy`.
+On `*` it will be `cross-origin`, else it will be `same-origin`
 
 [npm-url]: https://github.com/ponbike/openapi-express/actions/workflows/nodejs.yml
 [npm-image]: https://github.com/ponbike/openapi-express/actions/workflows/nodejs.yml/badge.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ponbike/openapi-express",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ponbike/openapi-express",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@hckrnews/express-callback": "^3.0.2",
         "@hckrnews/validator": "^5.0.1",
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3843,9 +3843,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001301",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-      "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+      "version": "1.0.30001303",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+      "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4351,9 +4351,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.0.tgz",
-      "integrity": "sha512-PCTcOQSXVo9FI1dB7AichJXMEvmiGCq0gnCpjfDUc8505uR+2MeLXWe+Ue4PN5UXa2isHSa78sr7L59fk+2mnQ==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
       "engines": {
         "node": ">=12"
       }
@@ -4375,9 +4375,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.53",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
-      "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
+      "version": "1.4.54",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.54.tgz",
+      "integrity": "sha512-jRAoneRdSxnpRHO0ANpnEUtQHXxlgfVjrLOnQSisw1ryjXJXvS0pJaR/v2B7S++/tRjgEDp4Sjn5nmgb6uTySw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5538,9 +5538,9 @@
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "node_modules/form-data": {
@@ -11303,9 +11303,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.3.0.tgz",
-      "integrity": "sha512-RY1c3y6uuHBTu4nZPXcvrv9cnKj6MbaNMZK1NDyGHrUbQOO5WmkuMo6wi93WFzSURJk0SboD1X9nM5CtQAu2Og=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.4.0.tgz",
+      "integrity": "sha512-oxTuL0NxBP61fYHN6VC7b+FB3UbLTBEuO04S2H2D5s4zvqsf0hRRXgZRdPTZ76UoTybeqIF5FNlR6PdYie9Uug=="
     },
     "node_modules/swagger-ui-express": {
       "version": "4.3.0",
@@ -13316,9 +13316,9 @@
       "integrity": "sha512-eyVhMjXW2tv2dP7cF2sI+lVoh1x44fjMbIEusXWEYf9ffpIm+68tYnGkb4R3O75Nw/n6SdyGTRAaDSvWDlHRog=="
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -14891,9 +14891,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001301",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-      "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+      "version": "1.0.30001303",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+      "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
       "dev": true
     },
     "chalk": {
@@ -15298,9 +15298,9 @@
       }
     },
     "dotenv": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.0.tgz",
-      "integrity": "sha512-PCTcOQSXVo9FI1dB7AichJXMEvmiGCq0gnCpjfDUc8505uR+2MeLXWe+Ue4PN5UXa2isHSa78sr7L59fk+2mnQ=="
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
     },
     "duplexify": {
       "version": "4.1.2",
@@ -15319,9 +15319,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.53",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.53.tgz",
-      "integrity": "sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==",
+      "version": "1.4.54",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.54.tgz",
+      "integrity": "sha512-jRAoneRdSxnpRHO0ANpnEUtQHXxlgfVjrLOnQSisw1ryjXJXvS0pJaR/v2B7S++/tRjgEDp4Sjn5nmgb6uTySw==",
       "dev": true
     },
     "emittery": {
@@ -16219,9 +16219,9 @@
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "form-data": {
@@ -20550,9 +20550,9 @@
       "dev": true
     },
     "swagger-ui-dist": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.3.0.tgz",
-      "integrity": "sha512-RY1c3y6uuHBTu4nZPXcvrv9cnKj6MbaNMZK1NDyGHrUbQOO5WmkuMo6wi93WFzSURJk0SboD1X9nM5CtQAu2Og=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.4.0.tgz",
+      "integrity": "sha512-oxTuL0NxBP61fYHN6VC7b+FB3UbLTBEuO04S2H2D5s4zvqsf0hRRXgZRdPTZ76UoTybeqIF5FNlR6PdYie9Uug=="
     },
     "swagger-ui-express": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ponbike/openapi-express",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "OpenAPI express",
   "files": [
     "src/openapi-express.js",

--- a/src/__mocks__/api.js
+++ b/src/__mocks__/api.js
@@ -14,7 +14,8 @@ const api = buildOpenapiExpress({
     })
   ],
   staticFolder: 'src/__fixtures__',
-  limit: '1mb'
+  limit: '1mb',
+  origin: 'https://localhost'
 })
 
 export default api

--- a/src/__tests__/app.e2e.js
+++ b/src/__tests__/app.e2e.js
@@ -28,6 +28,8 @@ describe('Test the server', () => {
 
     expect(response.status).toBe(200)
     expect(response.body.message).toEqual('ok')
+    expect(response.header['access-control-allow-origin']).toEqual('https://localhost')
+    expect(response.header['cross-origin-resource-policy']).toEqual('same-origin')
   })
 
   it('It should return status 404 for a unknown page (/v1/xyz)', async () => {

--- a/src/__tests__/origin-policy.js
+++ b/src/__tests__/origin-policy.js
@@ -1,9 +1,9 @@
 import { expect, describe, it } from '@jest/globals'
-import { getOriginPolicy } from '../openapi-express.js'
+import { getOriginResourcePolicy } from '../openapi-express.js'
 
 describe('Get origin policy test', () => {
   it('It should return cross-origin if the value is *', async () => {
-    const result = getOriginPolicy('*')
+    const result = getOriginResourcePolicy('*')
     expect(result).toEqual({
       crossOriginResourcePolicy: {
         policy: 'cross-origin'
@@ -12,7 +12,7 @@ describe('Get origin policy test', () => {
   })
 
   it('It should return same-origin if the value isnt *', async () => {
-    const result = getOriginPolicy('https://localhost')
+    const result = getOriginResourcePolicy('https://localhost')
     expect(result).toEqual({
       crossOriginResourcePolicy: {
         policy: 'same-origin'

--- a/src/__tests__/origin-policy.js
+++ b/src/__tests__/origin-policy.js
@@ -1,0 +1,22 @@
+import { expect, describe, it } from '@jest/globals'
+import { getOriginPolicy } from '../openapi-express.js'
+
+describe('Get origin policy test', () => {
+  it('It should return cross-origin if the value is *', async () => {
+    const result = getOriginPolicy('*')
+    expect(result).toEqual({
+      crossOriginResourcePolicy: {
+        policy: 'cross-origin'
+      }
+    })
+  })
+
+  it('It should return same-origin if the value isnt *', async () => {
+    const result = getOriginPolicy('https://localhost')
+    expect(result).toEqual({
+      crossOriginResourcePolicy: {
+        policy: 'same-origin'
+      }
+    })
+  })
+})

--- a/src/openapi-express.js
+++ b/src/openapi-express.js
@@ -63,7 +63,11 @@ const buildOpenapiExpress = ({
   app.set('version', version)
   app.use(cors(corsOptions))
   app.use(compression())
-  app.use(helmet())
+  app.use(helmet({
+    crossOriginResourcePolicy: {
+      policy: origin === '*' ? 'cross-origin' : 'same-origin'
+    }
+  }))
   app.use(express.json({ limit }))
   app.use((request, response, next) => {
     response.setHeader('X-Powered-By', poweredBy)

--- a/src/openapi-express.js
+++ b/src/openapi-express.js
@@ -94,7 +94,7 @@ const buildOpenapiExpress = ({
 }
 
 /**
- * Get the origin policy
+ * Get the origin resource policy
  *
  * @param {string} origin
  *

--- a/src/openapi-express.js
+++ b/src/openapi-express.js
@@ -63,11 +63,7 @@ const buildOpenapiExpress = ({
   app.set('version', version)
   app.use(cors(corsOptions))
   app.use(compression())
-  app.use(helmet({
-    crossOriginResourcePolicy: {
-      policy: origin === '*' ? 'cross-origin' : 'same-origin'
-    }
-  }))
+  app.use(helmet(getOriginPolicy(origin)))
   app.use(express.json({ limit }))
   app.use((request, response, next) => {
     response.setHeader('X-Powered-By', poweredBy)
@@ -96,6 +92,12 @@ const buildOpenapiExpress = ({
 
   return app
 }
+
+const getOriginPolicy = (origin) => ({
+  crossOriginResourcePolicy: {
+    policy: origin === '*' ? 'cross-origin' : 'same-origin'
+  }
+})
 
 /**
  * Connect the openapi spec to the controllers.
@@ -146,5 +148,6 @@ export {
   logger,
   stackdriver,
   apiValidator,
-  apiSchema
+  apiSchema,
+  getOriginPolicy
 }

--- a/src/openapi-express.js
+++ b/src/openapi-express.js
@@ -93,6 +93,13 @@ const buildOpenapiExpress = ({
   return app
 }
 
+/**
+ * Get the origin policy
+ *
+ * @param {string} origin
+ *
+ * @return {{ crossOriginResourcePolicy: { policy: string } }}
+ */
 const getOriginPolicy = (origin) => ({
   crossOriginResourcePolicy: {
     policy: origin === '*' ? 'cross-origin' : 'same-origin'

--- a/src/openapi-express.js
+++ b/src/openapi-express.js
@@ -63,7 +63,7 @@ const buildOpenapiExpress = ({
   app.set('version', version)
   app.use(cors(corsOptions))
   app.use(compression())
-  app.use(helmet(getOriginPolicy(origin)))
+  app.use(helmet(getOriginResourcePolicy(origin)))
   app.use(express.json({ limit }))
   app.use((request, response, next) => {
     response.setHeader('X-Powered-By', poweredBy)
@@ -100,7 +100,7 @@ const buildOpenapiExpress = ({
  *
  * @return {{ crossOriginResourcePolicy: { policy: string } }}
  */
-const getOriginPolicy = (origin) => ({
+const getOriginResourcePolicy = (origin) => ({
   crossOriginResourcePolicy: {
     policy: origin === '*' ? 'cross-origin' : 'same-origin'
   }
@@ -156,5 +156,5 @@ export {
   stackdriver,
   apiValidator,
   apiSchema,
-  getOriginPolicy
+  getOriginResourcePolicy
 }


### PR DESCRIPTION
When trying to load static assets from the public directory the user gets the following error in Chrome on the request:
`net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin 200`

The network tab gives more information about this error, see below.
```
cross-origin-resource-policy
To use this resource from a different origin, the server may relax the cross-origin resource policy response header:
Cross-Origin-Resource-Policy: same-siteChoose this option if the resource and the document are served from the same site.
Cross-Origin-Resource-Policy: cross-originOnly choose this option if an arbitrary website including this resource does not impose a security risk.
```

This package uses helmet that does not add this header by default. In this change we're adding the header and setting it to 'cross-site' or 'same-origin' depending on the origin configuration.